### PR TITLE
Making it possible to add more detailed styles to the respirator picker

### DIFF
--- a/client/routes/app/respirator-picker/RespiratorPicker.html
+++ b/client/routes/app/respirator-picker/RespiratorPicker.html
@@ -1,3 +1,35 @@
 <div class="respirator-picker">
 	{{{ html }}}
 </div>
+
+<style>
+h2 {
+	display: none;
+}
+
+ul.answer-links {
+	padding: 0;
+	list-style-type: none;
+}
+
+ul.answer-links li {
+	padding: 8px 0;
+	display: flex;
+}
+
+ul.answer-links a {
+	text-align: center;
+	padding: 8px;
+	border: 2px solid black;
+	width: 100%;
+}
+
+.decision-footer {
+	font-size: smaller;
+	border: 1px solid gray;
+	padding: 0 8px;
+}
+.decision-footer p {
+	margin: 8px 0;
+}
+</style>

--- a/client/routes/fonts.css
+++ b/client/routes/fonts.css
@@ -1,0 +1,3 @@
+body {
+	font-family: Verdana, "Helvetica Neue", sans-serif;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,11 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "@types/node": {
+      "version": "8.0.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
+      "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ=="
+    },
     "abstract-state-router": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/abstract-state-router/-/abstract-state-router-6.0.4.tgz",
@@ -2954,6 +2959,14 @@
       "requires": {
         "error-ex": "1.3.1",
         "json-parse-better-errors": "1.0.1"
+      }
+    },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "requires": {
+        "@types/node": "8.0.53"
       }
     },
     "path-is-absolute": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "loud-rejection": "^1.6.0",
     "make-dir": "^1.1.0",
     "npm-run-all": "^4.1.2",
+    "parse5": "^3.0.3",
     "pify": "^3.0.0",
     "postcss-alt-cli": "^1.0.0",
     "precss": "^2.0.0",

--- a/twine-parser/add-div-around-footer-test.js
+++ b/twine-parser/add-div-around-footer-test.js
@@ -1,0 +1,27 @@
+const test = require(`tape`)
+const modify = require(`./add-div-around-footer`)
+
+test(`Everything after the <hr> goes into a div with a class`, t => {
+	const input = `<p>Will you use the respirator in an oxygen-deficient<sup>*</sup> atmosphere?</p>
+<ul>
+<li><a href="7">Yes</a></li>
+<li><a href="3">No</a></li>
+</ul>
+<hr>
+<p><sup>*</sup>Oxygen deficient is less than 19.5% oxygen.</p>`
+
+	const expected = `<p>Will you use the respirator in an oxygen-deficient<sup>*</sup> atmosphere?</p>
+<ul>
+<li><a href="7">Yes</a></li>
+<li><a href="3">No</a></li>
+</ul>
+<div class="decision-footer">
+<p><sup>*</sup>Oxygen deficient is less than 19.5% oxygen.</p>
+</div>`
+
+	const output = modify(input)
+
+	t.equal(output, expected)
+
+	t.end()
+})

--- a/twine-parser/add-div-around-footer.js
+++ b/twine-parser/add-div-around-footer.js
@@ -1,0 +1,20 @@
+const r = require(`regex-fun`)
+
+r.combine(
+	`<hr>`,
+	r.capture(r.anyNumber(/[.\n]/))
+)
+
+module.exports = html => {
+	const pieces = html.split(`<hr>`)
+
+	if (pieces.length === 1) {
+		return html
+	}
+
+	const footer = pieces.pop()
+
+	const rest = pieces.join(``)
+
+	return `${ rest }<div class="decision-footer">${ footer }\n</div>`
+}

--- a/twine-parser/add-ul-answer-links-class-test.js
+++ b/twine-parser/add-ul-answer-links-class-test.js
@@ -1,0 +1,42 @@
+const test = require(`tape`)
+const modify = require(`./add-ul-answer-links-class`)
+
+test(`Sets a class on an unordered list that contains nothing but links`, t => {
+	const input = `<p>Will you use the respirator in an oxygen-deficient<sup>*</sup> atmosphere?</p>
+<ul>
+<li><a href="7">Yes</a></li>
+<li><a href="3">No</a></li>
+</ul>`
+
+	const expected = `<p>Will you use the respirator in an oxygen-deficient<sup>*</sup> atmosphere?</p>
+<ul class="answer-links">
+<li><a href="7">Yes</a></li>
+<li><a href="3">No</a></li>
+</ul>`
+
+	const output = modify(input)
+
+	t.equal(output, expected)
+
+	t.end()
+})
+
+test(`Don't touch lists with items that contain anything other than a link`, t => {
+	const input = `<p>Will you use the respirator in an oxygen-deficient<sup>*</sup> atmosphere?</p>
+<ul>
+<li>Yes</li>
+<li><a href="3">No</a></li>
+</ul>`
+
+	const expected = `<p>Will you use the respirator in an oxygen-deficient<sup>*</sup> atmosphere?</p>
+<ul>
+<li>Yes</li>
+<li><a href="3">No</a></li>
+</ul>`
+
+	const output = modify(input)
+
+	t.equal(output, expected)
+
+	t.end()
+})

--- a/twine-parser/add-ul-answer-links-class.js
+++ b/twine-parser/add-ul-answer-links-class.js
@@ -1,0 +1,76 @@
+const { parseFragment, serialize } = require(`parse5`)
+
+module.exports = html => {
+	const parsed = parseFragment(html)
+
+	// console.log(parsed)
+
+	const altered = transformRecursively(parsed, allTransforms(
+		addAnswerLinksClass
+	))
+
+	return serialize(altered)
+}
+
+const tagIs = tagName => node => node.tagName === tagName
+const nodeIs = nodeName => node => node.nodeName === nodeName
+const either = (thisCondition, thatCondition) => node => thisCondition(node) || thatCondition(node)
+
+const allConditionsMatch = (...conditions) => node =>
+	conditions.every(condition => condition(node))
+const allChildrenMatch = condition => node =>
+	!!node.childNodes && node.childNodes.every(condition)
+const allTransforms = (...transforms) => node =>
+	transforms.reduce((acc, transform) => transform(acc), node)
+
+const makeConditionalTransform = (condition, transform) => node => condition(node)
+	? transform(node)
+	: node
+
+const textOr = condition => either(nodeIs(`#text`), condition)
+
+const addAnswerLinksClass = makeConditionalTransform(
+	allConditionsMatch(tagIs(`ul`), allChildrenMatch(textOr(allChildrenMatch(tagIs(`a`))))),
+	node => addClass(node, `answer-links`)
+)
+
+function transformRecursively(node, transform) {
+	const transformed = transform(node)
+
+	if (node.childNodes) {
+		const transformedChildren = node.childNodes.map(child =>
+			transformRecursively(child, transform)
+		)
+
+		return Object.assign({}, transform(node), {
+			childNodes: transformedChildren,
+		})
+	} else {
+		return transformed
+	}
+}
+
+function addClass(node, classString) {
+	if (node.attrs.some(({ name }) => name === `class`)) {
+		return node.attrs.map(attribute => {
+			if (attribute.name === `class`) {
+				return {
+					name: `class`,
+					value: addClassToString(attribute.value, classString),
+				}
+			} else {
+				return attribute
+			}
+		})
+	} else {
+		return Object.assign({}, node, {
+			attrs: [{ name: `class`, value: classString }],
+		})
+	}
+}
+
+function addClassToString(classString, newClass) {
+	const classes = new Set(classString.split(/ */))
+	classes.add(newClass)
+	return [ ...classes ].join(` `)
+}

--- a/twine-parser/readme.md
+++ b/twine-parser/readme.md
@@ -1,0 +1,14 @@
+This code takes a Twine story and spits out a map of question IDs to the question-asking HTML.
+
+This happens automatically before the build process.
+
+The output ends up in `client/data/decision-data.json`, and is not committed.
+
+Here are some things to know about the current parsing/output process:
+
+- markdown styling is applied via [remarkable](https://github.com/jonschlinkert/remarkable)
+- the name of the passage is added as a `h2` header at the top
+- anything after the last separator (`---`) is put inside of a `div` with class `decision-footer`
+- the list of answers (identified by assuming that any bullet list that contains only links is the answer list) is given the class `answer-links`
+
+To edit how these things all end up looking in the app, see `client/routes/app/respirator-picker/RespiratorPicker.html`


### PR DESCRIPTION
This hacks some classes in to the html that gets spit out by the twine -> html processor, so that it's possible to style things reasonably.

I put a readme in the `twine-parser` folder to hopefully save some confusion when coming back to this project in the future.