### PR TITLE
Fix automated testing on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           - v1-dependencies-
       - run:
           command: |
-              npm i
+              npm i --production
               npm run build
       - save_cache:
           paths:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "better-emitter": "^1.0.2",
     "better-match": "^1.0.2",
     "better-replace": "^1.0.2",
-    "cordova": "^7.1.0",
     "del-cli": "^1.1.0",
     "download": "^6.2.5",
     "glob-module-file": "^2.2.0",
@@ -82,6 +81,7 @@
     "tape-catch": "^1.0.6"
   },
   "devDependencies": {
+    "cordova": "^7.1.0",
     "gaze": "^1.1.2",
     "live-server": "^1.2.0",
     "runjs": "^4.3.0",


### PR DESCRIPTION
Works around https://github.com/npm/npm/issues/17444

npm has a bug that causes it to fail when installing npm as a dependency.

cordova has npm as a dependency.